### PR TITLE
bugfix for is_prime method for params 0 and 1

### DIFF
--- a/src/playcrypt/tools.py
+++ b/src/playcrypt/tools.py
@@ -155,6 +155,9 @@ def bitwise_complement_string(s):
 
 # https://rosettacode.org/wiki/Miller%E2%80%93Rabin_primality_test#Python:_Proved_correct_up_to_large_N
 def is_prime(n, _precision_for_huge_n=16):
+    if(n == 0 or n == 1):
+        return False
+        
     def _try_composite(a, d, n, s):
         if pow(a, d, n) == 1:
             return False


### PR DESCRIPTION
Currently **is_prime method** in tools.py returns **True** for the parameters integer **0** and **1**. 
This PR fixes this issue with an additional if block.
